### PR TITLE
Add newer build-and-deploy YAML file.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,18 +43,21 @@ jobs:
       matrix:
         # os: [] #for testing with act
         include:
+          - os: ubuntu-24.04
+            compiler: g++
+            target: Linux
+
           - os: ubuntu-22.04
             compiler: g++
             target: Linux
 
-          - os: ubuntu-20.04
-            compiler: g++
-            target: Linux
-          
-          - os: macos-12
+          - os: macos-15
             compiler: clang
           
-          - os: macos-11
+          - os: macos-14
+            compiler: clang
+
+          - os: macos-13
             compiler: clang
           
     steps:
@@ -69,7 +72,7 @@ jobs:
       - name: Install - MacOS
         if: startsWith(matrix.os,'macos')
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install git coreutils cmake gcc gsl xerces-c xsd || true
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install coreutils gsl xerces-c xsd || true
           HOMEBREW_NO_AUTO_UPDATE=1 brew link --overwrite xsd
       
       - name: Infos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Copyright © 2005-2013 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 # Licence: GNU General Public Licence version 2 or later (see COPYING)
 
-cmake_minimum_required (VERSION 3.0)
 
 project (OpenMalaria CXX)
 


### PR DESCRIPTION
This is so that we can leverage GitHub's runners to make a macOS 15 build of OpenMalaria v46.0.